### PR TITLE
Fix reference to old posterior attribute

### DIFF
--- a/notebooks/MLR-test.ipynb
+++ b/notebooks/MLR-test.ipynb
@@ -146,7 +146,7 @@
     "    \"\"\"\n",
     "    Use posterior beta to get posterior frequenicies based on matrix X.\n",
     "    \"\"\"\n",
-    "    beta = jnp.array(dataset.posterior[\"beta\"])[1]\n",
+    "    beta = jnp.array(dataset[\"beta\"])\n",
     "    logits = jnp.dot(X, beta) # Logit frequencies by variant\n",
     "    return softmax(logits, axis=-1)"
    ]


### PR DESCRIPTION
Corrects an outdated reference to the `posterior` attribute of a given dataset when calculating posterior frequencies in the "MLR test" notebook.